### PR TITLE
US3_roleUpdateRestrictions - Role update restrictions implemented

### DIFF
--- a/src/main/java/com/cankus/controller/UserController.java
+++ b/src/main/java/com/cankus/controller/UserController.java
@@ -70,7 +70,29 @@ public class UserController {
                              BindingResult bindingResult,
                              RedirectAttributes redirectAttributes,
                              Model model) {
-        //Todo US3-AC.role:  Restrict condition update for roles: ADMIN, MANAGER, INSTRUCTOR
+
+        if (!userService.canUpdateRole(user.getId())) {
+            String role = userService.findById(user.getId()).getRole().getDescription().toUpperCase();
+            String errorMessage;
+
+                switch (role) {
+                    case "ADMIN":
+                    errorMessage = "This admin is unique in the system. Not allowed to update.";
+                    break;
+                case "MANAGER":
+                    errorMessage = "This manager is responsible for one or more courses. Not allowed to update.";
+                    break;
+                case "INSTRUCTOR":
+                    errorMessage = "This instructor is responsible for one or more lessons. Not allowed to update.";
+                    break;
+                default:
+                    errorMessage = "Not allowed to update role.";
+            }
+
+            redirectAttributes.addFlashAttribute("error", errorMessage);
+            return "redirect:/user/update/" + user.getId();
+        }
+
 
         // password ve confirmPassword match olmalı
         if (userService.isPasswordMatched(user.getPassword(), user.getConfirmPassword())) {

--- a/src/main/java/com/cankus/repository/CourseRepository.java
+++ b/src/main/java/com/cankus/repository/CourseRepository.java
@@ -4,4 +4,5 @@ import com.cankus.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CourseRepository extends JpaRepository<Course,Long> {
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/cankus/repository/LessonRepository.java
+++ b/src/main/java/com/cankus/repository/LessonRepository.java
@@ -4,4 +4,6 @@ import com.cankus.entity.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LessonRepository extends JpaRepository<Lesson,Long> {
+    boolean existsById(Long id);
+
 }

--- a/src/main/java/com/cankus/service/CourseService.java
+++ b/src/main/java/com/cankus/service/CourseService.java
@@ -15,4 +15,7 @@ public interface CourseService {
     void update(CourseDto courseDto);
 
     void delete(Long id);
+
+    boolean hasAssignedCourses(Long managerId);
+
 }

--- a/src/main/java/com/cankus/service/LessonService.java
+++ b/src/main/java/com/cankus/service/LessonService.java
@@ -15,4 +15,7 @@ public interface LessonService {
     void update(LessonDto lessonDto);
 
     void delete(Long id);
+
+    boolean hasAssignedLessons(Long instructorId);
+
 }

--- a/src/main/java/com/cankus/service/UserService.java
+++ b/src/main/java/com/cankus/service/UserService.java
@@ -25,6 +25,11 @@ public interface UserService {
 
     List<UserDto> getAllInstructors();
 
+    boolean canUpdateRole(Long id);
+
+    boolean isSoleAdmin(Long id);
+
+
 
 
 }

--- a/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
@@ -56,4 +56,9 @@ public class CourseServiceImplementation implements CourseService {
         courseRepository.save(courseInDB);
 
     }
+
+    @Override
+    public boolean hasAssignedCourses(Long managerId) {
+        return courseRepository.existsById(managerId);
+    }
 }

--- a/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
@@ -57,4 +57,9 @@ public class LessonServiceImplementation implements LessonService {
         lessonInDB.setDeleted(true);
         lessonRepository.save(lessonInDB);
     }
+
+    @Override
+    public boolean hasAssignedLessons(Long instructorId) {
+        return lessonRepository.existsById(instructorId);
+    }
 }


### PR DESCRIPTION
 US3 – Role Update Restrictions
Summary
This PR implements business rules to restrict role updates based on user responsibilities and uniqueness constraints.

Changes Introduced
Course Responsibility Check:

courseRepository: Added existsBy() to determine if a manager is assigned to any course.

courseService & courseServiceImplementation: Added hasAssignedCourses() method for service-level logic.

Lesson Responsibility Check:

lessonRepository: Added existsById() to verify if an instructor is assigned to any lesson.

lessonService & lessonServiceImplementation: Added hasAssignedLesson() method.

Role Update Logic:

userService & userServiceImplementation: Added canUpdateRole() and isSoleAdmin() methods to prevent:

Updates if the user is the only Admin

Updates if the Manager has assigned courses

Updates if the Instructor has assigned lessons

UserController:

Enhanced updateUser() to:

Block role changes based on the user's role and assignments.

Display specific error messages per role.

Business Rules Enforced
Admin role can’t be updated if the user is the only Admin.

Manager role can’t be updated if responsible for one or more courses.

Instructor role can’t be updated if responsible for one or more lessons.

Why These Changes
To maintain system integrity by preventing critical role modifications that could leave orphaned responsibilities or violate business constraints.

