### PR TITLE
dev2/US4_deleteUserRestrictions

### DIFF
--- a/src/main/java/com/cankus/controller/UserController.java
+++ b/src/main/java/com/cankus/controller/UserController.java
@@ -111,7 +111,27 @@ public class UserController {
     @GetMapping("/delete/{id}")
     public String deleteUser(@PathVariable Long id,RedirectAttributes redirectAttributes){
 
-        //Todo  US4-AC.In some cases not allowed to delete users:  Restrict condition delete for roles: ADMIN, MANAGER, INSTRUCTOR
+        if (!userService.canDeleteUser(id)) {
+            String role = userService.findById(id).getRole().getDescription();
+            String errorMessage;
+
+            switch (role.toUpperCase()) {
+                case "ADMIN":
+                    errorMessage = "This admin is unique in the system. Not allowed to delete.";
+                    break;
+                case "MANAGER":
+                    errorMessage = "This manager is responsible for one or more courses. Not allowed to delete.";
+                    break;
+                case "INSTRUCTOR":
+                    errorMessage = "This instructor is responsible for one or more lessons. Not allowed to delete.";
+                    break;
+                default:
+                    errorMessage = "Not allowed to delete user.";
+            }
+
+            redirectAttributes.addFlashAttribute("error", errorMessage);
+            return "redirect:/user/create";
+        }
 
 
         userService.delete(id);

--- a/src/main/java/com/cankus/controller/UserController.java
+++ b/src/main/java/com/cankus/controller/UserController.java
@@ -70,7 +70,29 @@ public class UserController {
                              BindingResult bindingResult,
                              RedirectAttributes redirectAttributes,
                              Model model) {
-        //Todo US3-AC.role:  Restrict condition update for roles: ADMIN, MANAGER, INSTRUCTOR
+
+        if (!userService.canUpdateRole(user.getId())) {
+            String role = userService.findById(user.getId()).getRole().getDescription().toUpperCase();
+            String errorMessage;
+
+                switch (role) {
+                    case "ADMIN":
+                    errorMessage = "This admin is unique in the system. Not allowed to update.";
+                    break;
+                case "MANAGER":
+                    errorMessage = "This manager is responsible for one or more courses. Not allowed to update.";
+                    break;
+                case "INSTRUCTOR":
+                    errorMessage = "This instructor is responsible for one or more lessons. Not allowed to update.";
+                    break;
+                default:
+                    errorMessage = "Not allowed to update role.";
+            }
+
+            redirectAttributes.addFlashAttribute("error", errorMessage);
+            return "redirect:/user/update/" + user.getId();
+        }
+
 
         // password ve confirmPassword match olmalı
         if (userService.isPasswordMatched(user.getPassword(), user.getConfirmPassword())) {

--- a/src/main/java/com/cankus/repository/CourseRepository.java
+++ b/src/main/java/com/cankus/repository/CourseRepository.java
@@ -4,4 +4,5 @@ import com.cankus.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CourseRepository extends JpaRepository<Course,Long> {
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/cankus/repository/CourseRepository.java
+++ b/src/main/java/com/cankus/repository/CourseRepository.java
@@ -4,5 +4,5 @@ import com.cankus.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CourseRepository extends JpaRepository<Course,Long> {
-    boolean existsById(Long id);
+    boolean existsByCourseManagerId(Long managerId);
 }

--- a/src/main/java/com/cankus/repository/LessonRepository.java
+++ b/src/main/java/com/cankus/repository/LessonRepository.java
@@ -4,4 +4,6 @@ import com.cankus.entity.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LessonRepository extends JpaRepository<Lesson,Long> {
+    boolean existsById(Long id);
+
 }

--- a/src/main/java/com/cankus/repository/LessonRepository.java
+++ b/src/main/java/com/cankus/repository/LessonRepository.java
@@ -4,6 +4,6 @@ import com.cankus.entity.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LessonRepository extends JpaRepository<Lesson,Long> {
-    boolean existsById(Long id);
+    boolean existsByInstructorId(Long instructorId);
 
 }

--- a/src/main/java/com/cankus/service/CourseService.java
+++ b/src/main/java/com/cankus/service/CourseService.java
@@ -15,4 +15,7 @@ public interface CourseService {
     void update(CourseDto courseDto);
 
     void delete(Long id);
+
+    boolean hasAssignedCourses(Long managerId);
+
 }

--- a/src/main/java/com/cankus/service/LessonService.java
+++ b/src/main/java/com/cankus/service/LessonService.java
@@ -15,4 +15,7 @@ public interface LessonService {
     void update(LessonDto lessonDto);
 
     void delete(Long id);
+
+    boolean hasAssignedLessons(Long instructorId);
+
 }

--- a/src/main/java/com/cankus/service/UserService.java
+++ b/src/main/java/com/cankus/service/UserService.java
@@ -29,6 +29,8 @@ public interface UserService {
 
     boolean isSoleAdmin(Long id);
 
+    boolean canDeleteUser(Long id);
+
 
 
 

--- a/src/main/java/com/cankus/service/UserService.java
+++ b/src/main/java/com/cankus/service/UserService.java
@@ -25,6 +25,11 @@ public interface UserService {
 
     List<UserDto> getAllInstructors();
 
+    boolean canUpdateRole(Long id);
+
+    boolean isSoleAdmin(Long id);
+
+
 
 
 }

--- a/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
@@ -59,6 +59,6 @@ public class CourseServiceImplementation implements CourseService {
 
     @Override
     public boolean hasAssignedCourses(Long managerId) {
-        return courseRepository.existsById(managerId);
+        return courseRepository.existsByCourseManagerId(managerId);
     }
 }

--- a/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
@@ -56,4 +56,9 @@ public class CourseServiceImplementation implements CourseService {
         courseRepository.save(courseInDB);
 
     }
+
+    @Override
+    public boolean hasAssignedCourses(Long managerId) {
+        return courseRepository.existsById(managerId);
+    }
 }

--- a/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
@@ -60,6 +60,6 @@ public class LessonServiceImplementation implements LessonService {
 
     @Override
     public boolean hasAssignedLessons(Long instructorId) {
-        return lessonRepository.existsById(instructorId);
+        return lessonRepository.existsByInstructorId(instructorId);
     }
 }

--- a/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
@@ -57,4 +57,9 @@ public class LessonServiceImplementation implements LessonService {
         lessonInDB.setDeleted(true);
         lessonRepository.save(lessonInDB);
     }
+
+    @Override
+    public boolean hasAssignedLessons(Long instructorId) {
+        return lessonRepository.existsById(instructorId);
+    }
 }

--- a/src/main/java/com/cankus/service/implementation/UserServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/UserServiceImplementation.java
@@ -124,5 +124,23 @@ public class UserServiceImplementation implements UserService {
         return admins.size() == 1 && admins.get(0).getId().equals(id);
     }
 
+    @Override
+    public boolean canDeleteUser(Long id) {
+        UserDto user = findById(id);
+        String role = user.getRole().getDescription();
+
+        switch (role.toUpperCase()) {
+            case "ADMIN":
+                return !isSoleAdmin(id);
+            case "MANAGER":
+                return !courseService.hasAssignedCourses(id);
+            case "INSTRUCTOR":
+                return !lessonService.hasAssignedLessons(id);
+            default:
+                return true;
+        }
+    }
+
+
 
 }


### PR DESCRIPTION
US4 - Delete User Role Restrictions
**Summary**
This PR introduces role-based deletion restrictions for users with ADMIN, MANAGER, and INSTRUCTOR roles. It ensures critical users cannot be deleted if doing so would violate system integrity or break logical dependencies.

**Features Implemented**
userService

Added canDeleteUser(Long id) method to determine if a user is eligible for deletion based on their role.

userServiceImplementation

Implemented canDeleteUser() using:

isSoleAdmin(id) → Prevent deletion of the only admin in the system.

courseService.hasAssignedCourses(id) → Block manager deletion if assigned to any course.

lessonService.hasAssignedLessons(id) → Block instructor deletion if assigned to any lesson.

userController

Integrated canDeleteUser() in deleteUser() method.

Displays descriptive error messages for restricted deletion cases.

**Deletion Rules**
Admin: Cannot delete if the only admin.

Manager: Cannot delete if responsible for one or more courses.

Instructor: Cannot delete if assigned to any lessons.