### PR TITLE
dev2/US19_ManagerCanDropCoursesFromStudents

### DIFF
--- a/src/main/java/com/cankus/controller/CourseController.java
+++ b/src/main/java/com/cankus/controller/CourseController.java
@@ -70,12 +70,16 @@ public class CourseController {
 
     @GetMapping("/delete/{id}")
     public String deleteCourse(@PathVariable Long id, RedirectAttributes redirectAttributes){
-        /** TODO US8: Before deleting a course, check if it has lessons.
-                If lessons exist, do not delete and show message: "This Course has either one or more than one lessons. Not allowed to delete".
-                If no lessons, first remove course from all students (courseStudent), then soft-delete course.
-                On successful delete, show message: "This Course is successfully deleted".
-         */
+        // *us8 -12
+       if(courseService.checkAssignedLesson(id)){
+           redirectAttributes.addFlashAttribute("error",
+                   "This Course has either one or more than one lessons. Not allowed to delete");
+           return "redirect:/course/create";
+       }
+
         courseService.delete(id);
+        // *us8 -13
+        redirectAttributes.addFlashAttribute("success", "This Course is successfully deleted");
         return "redirect:/course/create";
     }
 

--- a/src/main/java/com/cankus/controller/LessonController.java
+++ b/src/main/java/com/cankus/controller/LessonController.java
@@ -42,14 +42,8 @@ public class LessonController {
             model.addAttribute("instructors", userService.getAllInstructors());
             return "lesson/lesson-create";
         }
-        /*
-        Todo --> US10--> While new lesson is created,
-                this lesson should assign to the all students
-                who have already been enrolled to the course of this lesson.
-        */
         lessonService.save(lesson);
         return "redirect:/lesson/create";
-
     }
 
     @GetMapping("/update/{id}")

--- a/src/main/java/com/cankus/controller/StudentController.java
+++ b/src/main/java/com/cankus/controller/StudentController.java
@@ -2,6 +2,7 @@ package com.cankus.controller;
 
 import com.cankus.dto.StudentDto;
 import com.cankus.enums.State;
+import com.cankus.service.CourseStudentService;
 import com.cankus.service.StudentService;
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Controller;
@@ -14,9 +15,11 @@ import org.springframework.web.bind.annotation.*;
 public class StudentController {
 
     private final StudentService studentService;
+    private final CourseStudentService courseStudentService;
 
-    public StudentController(StudentService studentService) {
+    public StudentController(StudentService studentService, CourseStudentService courseStudentService) {
         this.studentService = studentService;
+        this.courseStudentService = courseStudentService;
     }
 
     @GetMapping("/create")
@@ -41,14 +44,14 @@ public class StudentController {
         return "redirect:/student/create";
     }
 
-    @GetMapping("update/{id}")
+    @GetMapping("/update/{id}")
     public String getUpdatePage(@PathVariable Long id, Model model) {
         model.addAttribute("student", studentService.findById(id));
         model.addAttribute("states", State.values());
         return "student/student-update";
     }
 
-    @PostMapping("update/{id}")
+    @PostMapping("/update/{id}")
     public String updateStudent(@Valid @ModelAttribute("student") StudentDto student,
                                 BindingResult bindingResult,
                                 Model model) {
@@ -66,5 +69,13 @@ public class StudentController {
         studentService.delete(id);
         return "redirect:/student/create";
     }
+
+    @GetMapping("/assign/{id}")
+    public String getAllStudent(@PathVariable Long id, Model model) {
+        model.addAttribute("studentCourses",courseStudentService.findAllByStudentId(id));
+        return "student/student-courses";
+    }
+
+
 
 }

--- a/src/main/java/com/cankus/controller/StudentController.java
+++ b/src/main/java/com/cankus/controller/StudentController.java
@@ -76,6 +76,13 @@ public class StudentController {
         return "student/student-courses";
     }
 
+    @GetMapping("/enroll/{courseStudentId}/{id}")
+    public String enrollCourse(@PathVariable Long courseStudentId,@PathVariable Long id){
+       courseStudentService.enroll(courseStudentId);
+        return "redirect:/student/assign/" + id; // Refresh assigned courses list
+
+    }
+
 
 
 }

--- a/src/main/java/com/cankus/controller/StudentController.java
+++ b/src/main/java/com/cankus/controller/StudentController.java
@@ -83,6 +83,13 @@ public class StudentController {
 
     }
 
+    @GetMapping("/drop/{courseStudentId}/{id}")
+    public String dropCourse(@PathVariable Long courseStudentId,@PathVariable Long id){
+        courseStudentService.drop(courseStudentId);
+        return "redirect:/student/assign/" + id; // Refresh assigned courses list
+
+    }
+
 
 
 }

--- a/src/main/java/com/cankus/converter/CourseDtoConverter.java
+++ b/src/main/java/com/cankus/converter/CourseDtoConverter.java
@@ -1,0 +1,27 @@
+package com.cankus.converter;
+
+
+import com.cankus.dto.CourseDto;
+import com.cankus.service.CourseService;
+import jakarta.annotation.Nullable;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CourseDtoConverter implements Converter <String,CourseDto> {
+
+    private final CourseService courseService;
+
+    public CourseDtoConverter(CourseService courseService) {
+        this.courseService = courseService;
+    }
+
+    @Override
+    public CourseDto convert(@Nullable String source) {
+        if (source == null || source.isBlank()) {
+            return null;
+        }
+        return courseService.findById(Long.parseLong(source));
+    }
+
+}

--- a/src/main/java/com/cankus/converter/RoleDtoConverter.java
+++ b/src/main/java/com/cankus/converter/RoleDtoConverter.java
@@ -2,6 +2,7 @@ package com.cankus.converter;
 
 import com.cankus.dto.RoleDto;
 import com.cankus.service.RoleService;
+import jakarta.annotation.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +17,10 @@ public class RoleDtoConverter implements Converter <String, RoleDto> {
     }
 
     @Override
-    public RoleDto convert(String source) {
+    public RoleDto convert(@Nullable String source) {
+        if (source == null || source.isBlank()) {
+            return null;
+        }
         return roleService.findById(Long.parseLong(source));
     }
 }

--- a/src/main/java/com/cankus/converter/UserDtoConverter.java
+++ b/src/main/java/com/cankus/converter/UserDtoConverter.java
@@ -2,6 +2,7 @@ package com.cankus.converter;
 
 import com.cankus.dto.UserDto;
 import com.cankus.service.UserService;
+import jakarta.annotation.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +16,10 @@ public class UserDtoConverter implements Converter<String,UserDto> {
     }
 
     @Override
-    public UserDto convert(String source) {
+    public UserDto convert(@Nullable String source) {
+        if (source == null || source.isBlank()) {
+            return null;
+        }
         return userService.findById(Long.parseLong(source)) ;
     }
 }

--- a/src/main/java/com/cankus/dto/CourseStudentDto.java
+++ b/src/main/java/com/cankus/dto/CourseStudentDto.java
@@ -1,9 +1,5 @@
 package com.cankus.dto;
 
-import com.cankus.entity.Course;
-import com.cankus.entity.Student;
-import jakarta.persistence.ManyToOne;
-
 public class CourseStudentDto {
 
     private Long id;

--- a/src/main/java/com/cankus/dto/LessonStudentDto.java
+++ b/src/main/java/com/cankus/dto/LessonStudentDto.java
@@ -1,0 +1,43 @@
+package com.cankus.dto;
+
+public class LessonStudentDto {
+
+    private Long id;
+
+    private StudentDto student;
+
+    private LessonDto lesson;
+
+    public LessonStudentDto() {
+    }
+
+    public LessonStudentDto(Long id, StudentDto student, LessonDto lesson) {
+        this.id = id;
+        this.student = student;
+        this.lesson = lesson;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public StudentDto getStudent() {
+        return student;
+    }
+
+    public void setStudent(StudentDto student) {
+        this.student = student;
+    }
+
+    public LessonDto getLesson() {
+        return lesson;
+    }
+
+    public void setLesson(LessonDto lesson) {
+        this.lesson = lesson;
+    }
+}

--- a/src/main/java/com/cankus/entity/LessonStudent.java
+++ b/src/main/java/com/cankus/entity/LessonStudent.java
@@ -1,0 +1,48 @@
+package com.cankus.entity;
+
+import com.cankus.entity.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "lesson_student")
+@SQLRestriction("is_deleted is false")
+public class LessonStudent extends BaseEntity {
+
+    @ManyToOne
+    private Lesson lesson;
+
+    @ManyToOne
+    private Student student;
+
+    public LessonStudent() {
+    }
+
+    public LessonStudent(Long id, Boolean isDeleted, LocalDateTime insertDateTime,
+                         Long insertUserId, LocalDateTime lastUpdateDateTime,
+                         Long lastUpdateUserId, Lesson lesson, Student student) {
+        super(id, isDeleted, insertDateTime, insertUserId, lastUpdateDateTime, lastUpdateUserId);
+        this.lesson = lesson;
+        this.student = student;
+    }
+
+    public Lesson getLesson() {
+        return lesson;
+    }
+
+    public void setLesson(Lesson lesson) {
+        this.lesson = lesson;
+    }
+
+    public Student getStudent() {
+        return student;
+    }
+
+    public void setStudent(Student student) {
+        this.student = student;
+    }
+}

--- a/src/main/java/com/cankus/mapper/LessonStudentMapper.java
+++ b/src/main/java/com/cankus/mapper/LessonStudentMapper.java
@@ -1,0 +1,36 @@
+package com.cankus.mapper;
+
+import com.cankus.dto.LessonStudentDto;
+import com.cankus.entity.LessonStudent;
+import org.modelmapper.ModelMapper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LessonStudentMapper {
+
+    private final ModelMapper modelMapper;
+
+    public LessonStudentMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    // DTO -> Entity
+    public LessonStudent convertToEntity(LessonStudentDto lessonStudentDto) {
+        return lessonStudentDto == null ? null : modelMapper.map(lessonStudentDto, LessonStudent.class);
+    }
+
+    // Entity -> DTO
+    public LessonStudentDto convertToDto(LessonStudent lessonStudent) {
+        return lessonStudent == null ? null : modelMapper.map(lessonStudent, LessonStudentDto.class);
+    }
+
+    // Liste Dönüşümü (Null-safe + Optimize)
+    public List<LessonStudentDto> convertToDtoList(List<LessonStudent> lessonStudents) {
+        return lessonStudents == null ? Collections.emptyList() :
+                lessonStudents.stream()
+                        .map(this::convertToDto)
+                        .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/cankus/repository/AddressRepository.java
+++ b/src/main/java/com/cankus/repository/AddressRepository.java
@@ -2,6 +2,9 @@ package com.cankus.repository;
 
 import com.cankus.entity.Address;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+
+@Repository
 public interface AddressRepository extends JpaRepository<Address,Long> {
 }

--- a/src/main/java/com/cankus/repository/CourseRepository.java
+++ b/src/main/java/com/cankus/repository/CourseRepository.java
@@ -2,7 +2,9 @@ package com.cankus.repository;
 
 import com.cankus.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CourseRepository extends JpaRepository<Course,Long> {
     boolean existsByCourseManagerId(Long managerId);
 }

--- a/src/main/java/com/cankus/repository/CourseRepository.java
+++ b/src/main/java/com/cankus/repository/CourseRepository.java
@@ -4,7 +4,13 @@ import com.cankus.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CourseRepository extends JpaRepository<Course,Long> {
+
     boolean existsByCourseManagerId(Long managerId);
+    // Get all non-deleted courses
+    List<Course> findAllByIsDeletedFalse();
+
 }

--- a/src/main/java/com/cankus/repository/CourseStudentRepository.java
+++ b/src/main/java/com/cankus/repository/CourseStudentRepository.java
@@ -2,14 +2,18 @@ package com.cankus.repository;
 
 import com.cankus.entity.CourseStudent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface CourseStudentRepository extends JpaRepository<CourseStudent, Long> {
 
     List<CourseStudent> findByStudentIdAndCourseIsDeletedFalseAndStudentIsDeletedFalse(Long studentId);
     // *us8-3     -> CSSImpl
     List<CourseStudent> findAllByCourseId(Long id);
+
+    List<CourseStudent> findAllByCourseIdAndIsEnrolled(Long courseId, boolean enrolled);
+
 
 }

--- a/src/main/java/com/cankus/repository/CourseStudentRepository.java
+++ b/src/main/java/com/cankus/repository/CourseStudentRepository.java
@@ -2,6 +2,8 @@ package com.cankus.repository;
 
 import com.cankus.entity.CourseStudent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,13 +11,22 @@ import java.util.List;
 @Repository
 public interface CourseStudentRepository extends JpaRepository<CourseStudent, Long> {
 
-    List<CourseStudent> findByStudentIdAndCourseIsDeletedFalseAndStudentIsDeletedFalse(Long studentId);
     // *us8-3     -> CSSImpl
     List<CourseStudent> findAllByCourseId(Long id);
 
     List<CourseStudent> findAllByCourseIdAndIsEnrolled(Long courseId, boolean enrolled);
 
     boolean existsByCourseIdAndStudentId(Long courseId,Long studentId);
+
+    // 1. SEÇENEK (Derived Query - Tercih edilen)
+    List<CourseStudent> findByStudentIdAndCourseIsDeletedFalseAndStudentIsDeletedFalse(Long studentId);
+
+    // 2. SEÇENEK (JPQL - Sadece özel durumlarda)
+//    @Query("SELECT cs FROM CourseStudent cs " +
+//            "WHERE cs.student.id = :studentId " +
+//            "AND cs.course.isDeleted = false " +
+//            "AND cs.student.isDeleted = false")
+//    List<CourseStudent> findByStudentId(@Param("studentId") Long studentId);
 
 
 }

--- a/src/main/java/com/cankus/repository/CourseStudentRepository.java
+++ b/src/main/java/com/cankus/repository/CourseStudentRepository.java
@@ -15,5 +15,7 @@ public interface CourseStudentRepository extends JpaRepository<CourseStudent, Lo
 
     List<CourseStudent> findAllByCourseIdAndIsEnrolled(Long courseId, boolean enrolled);
 
+    boolean existsByCourseIdAndStudentId(Long courseId,Long studentId);
+
 
 }

--- a/src/main/java/com/cankus/repository/CourseStudentRepository.java
+++ b/src/main/java/com/cankus/repository/CourseStudentRepository.java
@@ -9,5 +9,7 @@ import java.util.List;
 public interface CourseStudentRepository extends JpaRepository<CourseStudent, Long> {
 
     List<CourseStudent> findByStudentIdAndCourseIsDeletedFalseAndStudentIsDeletedFalse(Long studentId);
+    // *us8-3     -> CSSImpl
+    List<CourseStudent> findAllByCourseId(Long id);
 
 }

--- a/src/main/java/com/cankus/repository/LessonRepository.java
+++ b/src/main/java/com/cankus/repository/LessonRepository.java
@@ -3,7 +3,11 @@ package com.cankus.repository;
 import com.cankus.entity.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LessonRepository extends JpaRepository<Lesson,Long> {
     boolean existsByInstructorId(Long instructorId);
+    // *us8-8 -->LSImpl
+    List<Lesson> findAllByCourseId(Long courseId);
 
 }

--- a/src/main/java/com/cankus/repository/LessonRepository.java
+++ b/src/main/java/com/cankus/repository/LessonRepository.java
@@ -2,9 +2,10 @@ package com.cankus.repository;
 
 import com.cankus.entity.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
-
+@Repository
 public interface LessonRepository extends JpaRepository<Lesson,Long> {
     boolean existsByInstructorId(Long instructorId);
     // *us8-8 -->LSImpl

--- a/src/main/java/com/cankus/repository/LessonStudentRepository.java
+++ b/src/main/java/com/cankus/repository/LessonStudentRepository.java
@@ -1,0 +1,14 @@
+package com.cankus.repository;
+
+import com.cankus.entity.LessonStudent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LessonStudentRepository extends JpaRepository<LessonStudent,Long> {
+
+    // Check if assignment between this lesson and student already exists
+    // SELECT COUNT(*) > 0 FROM lesson_student WHERE lesson_id = :lessonId AND student_id = :studentId AND is_deleted = false;
+    boolean existsByLessonIdAndStudentId(Long lessonId, Long studentId);}
+
+

--- a/src/main/java/com/cankus/repository/LessonStudentRepository.java
+++ b/src/main/java/com/cankus/repository/LessonStudentRepository.java
@@ -4,11 +4,18 @@ import com.cankus.entity.LessonStudent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface LessonStudentRepository extends JpaRepository<LessonStudent,Long> {
+public interface LessonStudentRepository extends JpaRepository<LessonStudent, Long> {
 
     // Check if assignment between this lesson and student already exists
     // SELECT COUNT(*) > 0 FROM lesson_student WHERE lesson_id = :lessonId AND student_id = :studentId AND is_deleted = false;
-    boolean existsByLessonIdAndStudentId(Long lessonId, Long studentId);}
+    boolean existsByLessonIdAndStudentId(Long lessonId, Long studentId);
+
+
+    List<LessonStudent> findAllByLessonIdAndStudentId(Long lessonID, Long studentId);
+}
+
 
 

--- a/src/main/java/com/cankus/repository/RoleRepository.java
+++ b/src/main/java/com/cankus/repository/RoleRepository.java
@@ -2,6 +2,8 @@ package com.cankus.repository;
 
 import com.cankus.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RoleRepository extends JpaRepository<Role,Long> {
 }

--- a/src/main/java/com/cankus/repository/StudentRepository.java
+++ b/src/main/java/com/cankus/repository/StudentRepository.java
@@ -2,8 +2,18 @@ package com.cankus.repository;
 
 import com.cankus.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface StudentRepository extends JpaRepository<Student,Long> {
+    // Özel sorgu metodunu ekleyin
+    Optional<Student> findByIdAndIsDeletedFalse(Long id);
+
+    // Alternatif olarak bu şekilde de yazabilirsiniz:
+//   @Query("SELECT s FROM Student s WHERE s.id = :id AND s.isDeleted = false")
+//   Optional<Student> findActiveById(@Param("id") Long id);
 }

--- a/src/main/java/com/cankus/service/CourseService.java
+++ b/src/main/java/com/cankus/service/CourseService.java
@@ -18,4 +18,6 @@ public interface CourseService {
 
     boolean hasAssignedCourses(Long managerId);
 
+    // *us8-10   -->CSImpl
+    boolean checkAssignedLesson(Long courseId);
 }

--- a/src/main/java/com/cankus/service/CourseStudentService.java
+++ b/src/main/java/com/cankus/service/CourseStudentService.java
@@ -14,4 +14,6 @@ public interface CourseStudentService {
 
     List<CourseStudentDto> findAllByStudentId(Long id);
 
+    void enroll(Long courseStudentId);
+
 }

--- a/src/main/java/com/cankus/service/CourseStudentService.java
+++ b/src/main/java/com/cankus/service/CourseStudentService.java
@@ -1,13 +1,10 @@
 package com.cankus.service;
 
-import com.cankus.dto.CourseStudentDto;
-
-import java.util.List;
-
 public interface CourseStudentService {
 
     void assingNewCourseToAllStudent(Long courseId);
     //us8-1 --> CSSImpl
     void removeCourseStudentByCourse(Long courseId);
 
+    void assignAllCourseToNewStudent(Long studentId);
 }

--- a/src/main/java/com/cankus/service/CourseStudentService.java
+++ b/src/main/java/com/cankus/service/CourseStudentService.java
@@ -16,4 +16,5 @@ public interface CourseStudentService {
 
     void enroll(Long courseStudentId);
 
+    void drop(Long courseStudentId);
 }

--- a/src/main/java/com/cankus/service/CourseStudentService.java
+++ b/src/main/java/com/cankus/service/CourseStudentService.java
@@ -7,4 +7,7 @@ import java.util.List;
 public interface CourseStudentService {
 
     void assingNewCourseToAllStudent(Long courseId);
+    //us8-1 --> CSSImpl
+    void removeCourseStudentByCourse(Long courseId);
+
 }

--- a/src/main/java/com/cankus/service/CourseStudentService.java
+++ b/src/main/java/com/cankus/service/CourseStudentService.java
@@ -1,5 +1,9 @@
 package com.cankus.service;
 
+import com.cankus.dto.CourseStudentDto;
+
+import java.util.List;
+
 public interface CourseStudentService {
 
     void assingNewCourseToAllStudent(Long courseId);
@@ -7,4 +11,7 @@ public interface CourseStudentService {
     void removeCourseStudentByCourse(Long courseId);
 
     void assignAllCourseToNewStudent(Long studentId);
+
+    List<CourseStudentDto> findAllByStudentId(Long id);
+
 }

--- a/src/main/java/com/cankus/service/LessonService.java
+++ b/src/main/java/com/cankus/service/LessonService.java
@@ -18,4 +18,7 @@ public interface LessonService {
 
     boolean hasAssignedLessons(Long instructorId);
 
+    //us8-6 --LSImpl
+    List<LessonDto> getAllLessonsByCourseId(Long courseId);
+
 }

--- a/src/main/java/com/cankus/service/LessonStudentService.java
+++ b/src/main/java/com/cankus/service/LessonStudentService.java
@@ -2,11 +2,12 @@ package com.cankus.service;
 
 import com.cankus.entity.CourseStudent;
 import com.cankus.entity.Lesson;
-import com.cankus.entity.Student;
 
 import java.util.List;
 
 public interface LessonStudentService {
 
     void assignLessonToStudents(Lesson lesson, List<CourseStudent> students);
+
+    void removeLessonStudent(Long lessonId,Long studentId);
 }

--- a/src/main/java/com/cankus/service/LessonStudentService.java
+++ b/src/main/java/com/cankus/service/LessonStudentService.java
@@ -1,0 +1,12 @@
+package com.cankus.service;
+
+import com.cankus.entity.CourseStudent;
+import com.cankus.entity.Lesson;
+import com.cankus.entity.Student;
+
+import java.util.List;
+
+public interface LessonStudentService {
+
+    void assignLessonToStudents(Lesson lesson, List<CourseStudent> students);
+}

--- a/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/CourseServiceImplementation.java
@@ -6,6 +6,7 @@ import com.cankus.mapper.CourseMapper;
 import com.cankus.repository.CourseRepository;
 import com.cankus.service.CourseService;
 import com.cankus.service.CourseStudentService;
+import com.cankus.service.LessonService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,11 +19,13 @@ public class CourseServiceImplementation implements CourseService {
     private final CourseRepository courseRepository;
     private final CourseMapper courseMapper;
     private final CourseStudentService courseStudentService;
+    private final LessonService lessonService;
 
-    public CourseServiceImplementation(CourseRepository courseRepository, CourseMapper courseMapper, CourseStudentService courseStudentService) {
+    public CourseServiceImplementation(CourseRepository courseRepository, CourseMapper courseMapper, CourseStudentService courseStudentService, LessonService lessonService) {
         this.courseRepository = courseRepository;
         this.courseMapper = courseMapper;
         this.courseStudentService = courseStudentService;
+        this.lessonService = lessonService;
     }
 
     @Override
@@ -51,6 +54,7 @@ public class CourseServiceImplementation implements CourseService {
         courseRepository.save(course);
     }
 
+
     @Override
     public void delete(Long id) {
         Course courseInDB = courseRepository.findById(id)
@@ -58,11 +62,19 @@ public class CourseServiceImplementation implements CourseService {
 
         courseInDB.setDeleted(true);
         courseRepository.save(courseInDB);
-
+        // *us8-0 Remove all courseStudent -> CSSImpl
+        // *us8-5  --> LService
+        courseStudentService.removeCourseStudentByCourse(id);
     }
 
     @Override
     public boolean hasAssignedCourses(Long managerId) {
         return courseRepository.existsByCourseManagerId(managerId);
+    }
+
+    // *us8-11 --> C_Controller
+    @Override
+    public boolean checkAssignedLesson(Long courseId) {
+        return !lessonService.getAllLessonsByCourseId(courseId).isEmpty();
     }
 }

--- a/src/main/java/com/cankus/service/implementation/CourseStudentServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/CourseStudentServiceImplementation.java
@@ -1,6 +1,5 @@
 package com.cankus.service.implementation;
 
-import com.cankus.dto.CourseStudentDto;
 import com.cankus.entity.Course;
 import com.cankus.entity.CourseStudent;
 import com.cankus.mapper.CourseStudentMapper;
@@ -9,8 +8,6 @@ import com.cankus.repository.CourseStudentRepository;
 import com.cankus.repository.StudentRepository;
 import com.cankus.service.CourseStudentService;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -35,5 +32,18 @@ public class CourseStudentServiceImplementation implements CourseStudentService 
                 .stream()
                 .map(student -> new CourseStudent(false,course,student))
                 .forEach(courseStudentRepository::save);
+    }
+
+    //*us8-2 implement service method ->CSRepository
+    @Override
+    public void removeCourseStudentByCourse(Long courseId) {
+        //*us8-4 --> CSImpl
+        courseStudentRepository.findAllByCourseId(courseId)
+                .forEach(courseStudent -> {
+                    CourseStudent courseStudentInDB=courseStudentRepository.findById(courseStudent.getId())
+                            .orElseThrow(()->new NoSuchElementException("CourseStudent could not be found."));
+                    courseStudentInDB.setDeleted(true);
+                    courseStudentRepository.save(courseStudentInDB);
+                });
     }
 }

--- a/src/main/java/com/cankus/service/implementation/CourseStudentServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/CourseStudentServiceImplementation.java
@@ -1,8 +1,10 @@
 package com.cankus.service.implementation;
 
+import com.cankus.dto.CourseStudentDto;
 import com.cankus.entity.Course;
 import com.cankus.entity.CourseStudent;
 import com.cankus.entity.Student;
+import com.cankus.mapper.CourseStudentMapper;
 import com.cankus.repository.CourseRepository;
 import com.cankus.repository.CourseStudentRepository;
 import com.cankus.repository.StudentRepository;
@@ -20,11 +22,13 @@ public class CourseStudentServiceImplementation implements CourseStudentService 
     private final CourseStudentRepository courseStudentRepository;
     private final CourseRepository courseRepository;
     private final StudentRepository studentRepository;
+    private final CourseStudentMapper courseStudentMapper;
 
-    public CourseStudentServiceImplementation(CourseStudentRepository courseStudentRepository, CourseRepository courseRepository, StudentRepository studentRepository ) {
+    public CourseStudentServiceImplementation(CourseStudentRepository courseStudentRepository, CourseRepository courseRepository, StudentRepository studentRepository, CourseStudentMapper courseStudentMapper) {
         this.courseStudentRepository = courseStudentRepository;
         this.courseRepository = courseRepository;
         this.studentRepository = studentRepository;
+        this.courseStudentMapper = courseStudentMapper;
     }
 
     @Override
@@ -72,5 +76,12 @@ public class CourseStudentServiceImplementation implements CourseStudentService 
                 .collect(Collectors.toList());
         // 4. Toplu kaydet
         courseStudentRepository.saveAll(courseStudents);
+    }
+
+    @Override
+    public List<CourseStudentDto> findAllByStudentId(Long id) {
+        return courseStudentRepository.findByStudentIdAndCourseIsDeletedFalseAndStudentIsDeletedFalse(id)
+                .stream()
+                .map(courseStudentMapper::convertToDto).toList();
     }
 }

--- a/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonServiceImplementation.java
@@ -62,4 +62,14 @@ public class LessonServiceImplementation implements LessonService {
     public boolean hasAssignedLessons(Long instructorId) {
         return lessonRepository.existsByInstructorId(instructorId);
     }
+
+    // *us8-7 -->L_repository
+    @Override
+    public List<LessonDto> getAllLessonsByCourseId(Long courseId) {
+        //*us8-9  --> C_Service
+        return lessonRepository.findAllByCourseId(courseId)
+                .stream()
+                .map(lessonMapper::convertToDto)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cankus/service/implementation/LessonStudentServiceImplemantation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonStudentServiceImplemantation.java
@@ -9,6 +9,7 @@ import com.cankus.service.LessonStudentService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,6 +36,15 @@ public class LessonStudentServiceImplemantation implements LessonStudentService{
 
         // Save all lesson assignments in a batch operation for performance
         lessonStudentRepository.saveAll(lessonStudents);
+    }
+    @Override
+    public void removeLessonStudent(Long lessonId, Long studentId) {
+        lessonStudentRepository.findAllByLessonIdAndStudentId(lessonId, studentId)
+                .forEach(lessonStudent -> {
+                    LessonStudent lessonStudentInDb = lessonStudentRepository.findById(lessonStudent.getId()).orElseThrow(() -> new NoSuchElementException("LessonStudent could not be found"));
+                    lessonStudentInDb.setDeleted(true);
+                    lessonStudentRepository.save(lessonStudentInDb);
+                });
     }
 
 

--- a/src/main/java/com/cankus/service/implementation/LessonStudentServiceImplemantation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonStudentServiceImplemantation.java
@@ -1,0 +1,41 @@
+package com.cankus.service.implementation;
+
+import com.cankus.entity.CourseStudent;
+import com.cankus.entity.Lesson;
+import com.cankus.entity.LessonStudent;
+import com.cankus.entity.Student;
+import com.cankus.repository.LessonStudentRepository;
+import com.cankus.service.LessonStudentService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LessonStudentServiceImplemantation implements LessonStudentService{
+
+    private final LessonStudentRepository lessonStudentRepository;
+
+    public LessonStudentServiceImplemantation(LessonStudentRepository lessonStudentRepository) {
+        this.lessonStudentRepository = lessonStudentRepository;
+    }
+
+    @Transactional
+    @Override
+    public void assignLessonToStudents(Lesson lesson, List<CourseStudent> students) {
+        List<LessonStudent> lessonStudents = students.stream()
+                .filter(courseStudent -> !courseStudent.getCourse().isDeleted() && !courseStudent.getStudent().isDeleted())
+                .map(courseStudent -> {
+                    LessonStudent lessonStudent = new LessonStudent();
+                    lessonStudent.setLesson(lesson);
+                    lessonStudent.setStudent(courseStudent.getStudent());
+                    return lessonStudent;
+                })
+                .collect(Collectors.toList());
+
+        // Save all lesson assignments in a batch operation for performance
+        lessonStudentRepository.saveAll(lessonStudents);
+    }
+
+
+}

--- a/src/main/java/com/cankus/service/implementation/StudentServiceImplementation.java
+++ b/src/main/java/com/cankus/service/implementation/StudentServiceImplementation.java
@@ -5,8 +5,10 @@ import com.cankus.entity.Student;
 import com.cankus.mapper.StudentMapper;
 import com.cankus.repository.StudentRepository;
 import com.cankus.service.AddressService;
+import com.cankus.service.CourseStudentService;
 import com.cankus.service.StudentService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -17,11 +19,13 @@ public class StudentServiceImplementation implements StudentService {
     private final StudentRepository studentRepository;
     private final StudentMapper studentMapper;
     private final AddressService addressService;
+    private final CourseStudentService courseStudentService;
 
-    public StudentServiceImplementation(StudentRepository studentRepository , StudentMapper studentMapper, AddressService addressService) {
+    public StudentServiceImplementation(StudentRepository studentRepository , StudentMapper studentMapper, AddressService addressService , CourseStudentService courseStudentService) {
         this.studentRepository = studentRepository;
         this.studentMapper = studentMapper;
         this.addressService = addressService;
+        this.courseStudentService = courseStudentService;
     }
 
     public List<StudentDto> findAll(){
@@ -30,11 +34,12 @@ public class StudentServiceImplementation implements StudentService {
                 .map(studentMapper::convertToDto).collect(Collectors.toList());
     }
 
+    @Transactional
     @Override
     public void save(StudentDto studentDto) {
-        Student student = studentMapper.convertToEntity(studentDto);
-        studentRepository.save(student);
-
+        // 1) Convert DTO to Entity and save student
+        Student student = studentRepository.save(studentMapper.convertToEntity(studentDto));
+        courseStudentService.assignAllCourseToNewStudent(student.getId());
     }
 
     @Override

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -99,14 +99,14 @@ VALUES ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 'Admin'),
         ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 3, 3, false),
         ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 3, 4, false);
 
--- INSERT INTO lesson_student(insert_date_time, insert_user_id, is_deleted, last_update_date_time, last_update_user_id,
---                            lesson_id, student_id)
--- VALUES ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 3, 1),
---        ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 4, 1),
---        ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 3, 2),
---        ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 4, 2);
---
---
+ INSERT INTO lesson_student(insert_date_time, insert_user_id, is_deleted, last_update_date_time, last_update_user_id,
+                            lesson_id, student_id)
+ VALUES ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 3, 1),
+        ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 4, 1),
+        ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 3, 2),
+        ('2022-01-05 00:00:00', 1, false, '2022-01-05 00:00:00', 1, 4, 2);
+
+
 --
 -- INSERT INTO assessments(insert_date_time, insert_user_id, is_deleted, last_update_date_time, last_update_user_id,
 --                         lesson_student_id, grade_date, grade, instructor_impression_of_student)


### PR DESCRIPTION
US19: Manager Can Drop Courses from Students

### Overview
This PR implements the course drop functionality, allowing managers to remove courses from students. When a course is dropped:
- The student is unenrolled from the course (`enrolled = false`)
- All associated LessonStudent records are soft-deleted (`isDeleted = true`)

### Changes
- **CourseStudentService**
    - Added `drop(Long courseStudentId)` method signature.

- **LessonStudentService**
    - Added `removeLessonStudent(Long lessonId, Long studentId)` method for soft-deleting lesson enrollments.

- **CourseStudentServiceImpl**
    - Implemented `drop()` logic:
        - Sets `enrolled` flag to `false`
        - Calls `lessonStudentService.removeLessonStudent()` for each lesson under the course.

- **LessonStudentServiceImpl**
    - Implemented `removeLessonStudent()`:
        - Soft-deletes (`isDeleted = true`) matching LessonStudent records.

- **StudentController**
    - Added `/drop/{courseStudentId}/{id}` GET endpoint to trigger course drop from the UI.
    - Redirects back to assigned courses list after dropping.

### Technical Notes
- Soft delete approach ensures data is not physically removed but excluded from active queries.
- Drop logic cascades from CourseStudent → LessonStudent levels for consistency.

