### PR TITLE
dev2/US20_InstructorCanListStudents

### DIFF
--- a/src/main/java/com/cankus/controller/InstructorController.java
+++ b/src/main/java/com/cankus/controller/InstructorController.java
@@ -1,0 +1,26 @@
+package com.cankus.controller;
+
+import com.cankus.service.LessonStudentService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/instructor")
+public class InstructorController {
+
+    private final LessonStudentService lessonStudentService;
+
+    public InstructorController(LessonStudentService lessonStudentService) {
+        this.lessonStudentService = lessonStudentService;
+    }
+
+    @GetMapping("/students")
+    public String getAllStudentsWithThisInstructor( Model model) {
+        model.addAttribute("studentLessons", lessonStudentService.getLessonStudentsByInstructorId(4L));
+        return "instructor/general-assessment";
+    }
+
+}

--- a/src/main/java/com/cankus/mapper/LessonStudentMapper.java
+++ b/src/main/java/com/cankus/mapper/LessonStudentMapper.java
@@ -3,11 +3,13 @@ package com.cankus.mapper;
 import com.cankus.dto.LessonStudentDto;
 import com.cankus.entity.LessonStudent;
 import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Component
 public class LessonStudentMapper {
 
     private final ModelMapper modelMapper;

--- a/src/main/java/com/cankus/repository/LessonStudentRepository.java
+++ b/src/main/java/com/cankus/repository/LessonStudentRepository.java
@@ -13,8 +13,14 @@ public interface LessonStudentRepository extends JpaRepository<LessonStudent, Lo
     // SELECT COUNT(*) > 0 FROM lesson_student WHERE lesson_id = :lessonId AND student_id = :studentId AND is_deleted = false;
     boolean existsByLessonIdAndStudentId(Long lessonId, Long studentId);
 
-
     List<LessonStudent> findAllByLessonIdAndStudentId(Long lessonID, Long studentId);
+
+    //Us20-1 way
+   // List<LessonStudent> findLessonStudentByLessonIsDeletedAndStudentIsDeletedAndLessonInstructorId(Boolean lessonIsDeleted, Boolean studentIsDeleted, Long lessonInstructorId);
+    //Us20-2 way
+    List<LessonStudent> findByLessonIsDeletedFalseAndStudentIsDeletedFalseAndLessonInstructorId(Long instructorId);
+
+
 }
 
 

--- a/src/main/java/com/cankus/service/LessonStudentService.java
+++ b/src/main/java/com/cankus/service/LessonStudentService.java
@@ -1,5 +1,6 @@
 package com.cankus.service;
 
+import com.cankus.dto.LessonStudentDto;
 import com.cankus.entity.CourseStudent;
 import com.cankus.entity.Lesson;
 
@@ -10,4 +11,6 @@ public interface LessonStudentService {
     void assignLessonToStudents(Lesson lesson, List<CourseStudent> students);
 
     void removeLessonStudent(Long lessonId,Long studentId);
+
+    List<LessonStudentDto> getLessonStudentsByInstructorId(Long instructorId);
 }

--- a/src/main/java/com/cankus/service/implementation/LessonStudentServiceImplemantation.java
+++ b/src/main/java/com/cankus/service/implementation/LessonStudentServiceImplemantation.java
@@ -1,24 +1,28 @@
 package com.cankus.service.implementation;
 
+import com.cankus.dto.LessonStudentDto;
 import com.cankus.entity.CourseStudent;
 import com.cankus.entity.Lesson;
 import com.cankus.entity.LessonStudent;
-import com.cankus.entity.Student;
+import com.cankus.mapper.LessonStudentMapper;
 import com.cankus.repository.LessonStudentRepository;
 import com.cankus.service.LessonStudentService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
-public class LessonStudentServiceImplemantation implements LessonStudentService{
+public class LessonStudentServiceImplemantation implements LessonStudentService {
 
     private final LessonStudentRepository lessonStudentRepository;
+    private final LessonStudentMapper lessonStudentMapper;
 
-    public LessonStudentServiceImplemantation(LessonStudentRepository lessonStudentRepository) {
+    public LessonStudentServiceImplemantation(LessonStudentRepository lessonStudentRepository, LessonStudentMapper lessonStudentMapper) {
         this.lessonStudentRepository = lessonStudentRepository;
+        this.lessonStudentMapper = lessonStudentMapper;
     }
 
     @Transactional
@@ -37,6 +41,7 @@ public class LessonStudentServiceImplemantation implements LessonStudentService{
         // Save all lesson assignments in a batch operation for performance
         lessonStudentRepository.saveAll(lessonStudents);
     }
+
     @Override
     public void removeLessonStudent(Long lessonId, Long studentId) {
         lessonStudentRepository.findAllByLessonIdAndStudentId(lessonId, studentId)
@@ -45,6 +50,13 @@ public class LessonStudentServiceImplemantation implements LessonStudentService{
                     lessonStudentInDb.setDeleted(true);
                     lessonStudentRepository.save(lessonStudentInDb);
                 });
+    }
+
+    @Override
+    public List<LessonStudentDto> getLessonStudentsByInstructorId(Long instructorId) {
+        return lessonStudentRepository.findByLessonIsDeletedFalseAndStudentIsDeletedFalseAndLessonInstructorId(instructorId)
+                //.stream().map((element) -> modelMapper.map(element, LessonStudentDto.class)).toList();
+                .stream().map(lessonStudentMapper::convertToDto).toList();
     }
 
 

--- a/src/main/resources/templates/fragments/nav-bar.html
+++ b/src/main/resources/templates/fragments/nav-bar.html
@@ -164,6 +164,7 @@
         <li class="nav-item dropdown no-arrow">
             <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <!--Todo Security settings-->
                 <!--<span class="mr-2 d-none d-lg-inline text-gray-600 small" th:text="${#authentication.principal.getFullName()}"></span>-->
                 <span class="mr-2 d-none d-lg-inline text-gray-600 small"></span>
                 <img class="img-profile rounded-circle"

--- a/src/main/resources/templates/instructor/general-assessment.html
+++ b/src/main/resources/templates/instructor/general-assessment.html
@@ -20,7 +20,9 @@
             <!-- Topbar -->
             <nav th:replace="fragments/nav-bar::nav-bar"></nav>
             <div style="font-weight: bold; color: darkblue">
-                <h1 th:text="${'Students of '+#authentication.principal.getFullName()}"></h1>
+                <!--Todo Security settings -->
+               <!-- <h1 th:text="${'Students of '+#authentication.principal.getFullName()}"></h1>-->
+                <h1>Cankuş</h1>
             </div>
             <div class="container-fluid">
 


### PR DESCRIPTION
✨ Changes Implemented:
LessonStudentRepository

Added findLessonStudentByLessonIsDeletedAndStudentIsDeletedAndLessonInstructorId method to fetch lesson-student records for a specific instructor, only if both the lesson and student are active (not soft-deleted).

LessonStudentService

Added getLessonStudentsByInstructorId(Long instructorId) method definition to retrieve students assigned to an instructor.

LessonStudentServiceImpl

Implemented logic using repository to find students where both lesson.isDeleted = false and student.isDeleted = false.

Used lessonStudentMapper to map LessonStudent entities to LessonStudentDto.

Note: For now, used static instructor ID (4L) as dynamic security setup is pending.

StudentController

Added getAllStudentsWithThisInstructor endpoint at /students.

Calls service method with static instructor ID (4L) and adds data to studentLessons attribute for view rendering.

Returns the instructor/general-assessment page where instructor can view and assess students.

Nav-bar and General-assesment html--> Todo added for security settings

📚 Notes:
Security mechanism (dynamic instructor ID) is not yet implemented. Static instructor ID is used temporarily.

Soft-delete logic is respected (deleted lessons/students are not listed).

Data displayed is prepared for general assessment view (general-assessment.html).